### PR TITLE
Different method to determine successful requests

### DIFF
--- a/src/FrontApp.php
+++ b/src/FrontApp.php
@@ -246,8 +246,8 @@ class FrontApp
 
             $d = json_decode($response['body'], true);
 
-            if (isset($d['status']) && $d['status'] != '200' && isset($d['detail'])) {
-                $this->last_error = sprintf('%d: %s', $d['status'], $d['detail']);
+            if (isset($d['_error'])) {
+                $this->last_error = sprintf('%d: %s', $d['_error']['status'], $d['_error']['message']);
             } else {
                 $this->request_successful = true;
             }


### PR DESCRIPTION
The current check on 'status' isn't sufficient to detect errors. Not sure if the Front API has changed, but I think it's better to use the availability of the _error object to determine whether a request is successful or not. See http://dev.frontapp.com/#response-body-structure
